### PR TITLE
Added signs for bicycle/fishing/electronics shop

### DIFF
--- a/shop.json
+++ b/shop.json
@@ -63,6 +63,12 @@
             },
             {
                 "types": [
+                    "bicycle"
+                ],
+                "sign": "&#128690;"
+            },
+            {
+                "types": [
                     "boutique",
                     "clothes",
                     "fabric",
@@ -106,6 +112,18 @@
                     "mall"
                 ],
                 "sign": "fa-building"
+            },
+            {
+                "types": [
+                    "electronics"
+                ],
+                "sign": "&#128250;"
+            },
+            {
+                "types": [
+                    "fishing"
+                ],
+                "sign": "&#127907;"
             },
             {
                 "types": [

--- a/shop.json
+++ b/shop.json
@@ -127,6 +127,12 @@
             },
             {
                 "types": [
+                    "florist"
+                ],
+                "sign": "&#127799;"
+            },
+            {
+                "types": [
                     "hairdresser"
                 ],
                 "sign": "&#128113;"
@@ -154,6 +160,12 @@
                     "shoes"
                 ],
                 "sign": "&#128095;"
+            },
+            {
+                "types": [
+                    "travel_agency"
+                ],
+                "sign": "&#129523;"
             },
             {
                 "types": [


### PR DESCRIPTION
Hi,
First of all thank you very much for your openstreetbrowser project. It's a great service.

After searching for some shops I've discovered the emoji for the hairdresser, but the other shops had the default basket symbol.

![image](https://user-images.githubusercontent.com/362645/51336246-583e6480-1a84-11e9-9b75-8c98882302a6.png)

I've searched for _hairdresser_ and found the shop.json file. So I added entries for the other shops. For the electronics entry I chose a television emoji.

Please let me know if that's everything I had to do or if something is missing.

I'd be glad if you could merge this commit.

Kind regards,
Bernd 


## Original commit text:

Unicode symbols:
U+1F3A3: &#127907; fishing (fishing pole and fish)
U+1F6B2: &#128690; bicycle
U+1F4FA: &#128250; electronics (a television)

To find the html entity (&#128690; for example) I've searched the web for the unicode string (U+1F6B2 for example).