### PR TITLE
Paddling categories

### DIFF
--- a/paddling.yaml
+++ b/paddling.yaml
@@ -1,0 +1,5 @@
+type: index
+subCategories:
+  - id: paddling_amenities
+  - id: paddling_hazards
+  - id: paddling_routes

--- a/paddling_amenities.yaml
+++ b/paddling_amenities.yaml
@@ -1,0 +1,99 @@
+type: overpass
+name:
+  en: Paddling Amenities
+query:
+  '14': |-
+    (
+      node["canoe"="put_in"];
+      node["leisure"="slipway"];
+      way["canoe"="portage"];
+      nwr[shop~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
+      nwr[rental~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
+      nwr["canoe_rental"="yes"];
+      nwr["kayak_rental"="yes"];
+      nwr["standup_paddleboard_rental"="yes"];
+      nwr["dinghy_rental"="yes"];
+      nwr["pedalboat_rental"="yes"];
+    )
+feature:
+  pre: |-
+    {% if tags.canoe %}
+      {% set key = 'canoe' %}
+      {% set value = tags.canoe %}
+    {% elseif tags.leisure %}
+      {% set key = 'leisure' %}
+      {% set value = tags.leisure %}
+    {% elseif tags.shop %}
+      {% set key = 'shop' %}
+      {% set value = tags.shop %}
+    {% elseif tags.rental or tags.canoe_rental or tags.kayak_rental or tags.standup_paddleboard_rental or tags.dingy_rental or tags.pedalboat_rental %}
+      {% set key = 'shop' %}
+      {% set value = 'rental' %}
+    {% endif %}
+
+    {% set constIndex = (key ~ "=" ~ value) %}
+    {% set item = const[constIndex] %}
+
+  title: |
+    {{ localizedTag(tags, 'name') }}
+    {% if attribute(tags, 'ref') %}
+      ( {{ localizedTag(tags, 'ref') }} )
+    {% endif %}
+  description: |
+    {{ tagTrans(key, value) }}
+  body: |-
+    {% if constIndex in ['canoe=put_in', 'leisure=slipway','canoe=portage'] %}
+      <dl>
+        <dt>{{ keyTrans('Description') }}</dt>
+        <dd>{{ localizedTag(tags, 'description') }}</dd>
+
+        <dt>{{ keyTrans('Surface') }}</dt>
+        <dd>{{ attribute(tags, 'surface') ? tagTrans('surface', attribute(tags, 'surface')) : '' }}</dd>
+
+        <dt>{{ keyTrans('Operator') }}</dt>
+        <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
+
+        <dt>{{ keyTrans('Access') }}</dt>
+        <dd>{{ attribute(tags, 'access') ? tagTrans('access', attribute(tags, 'access')) : '' }}</dd>
+
+        <dt>{{ keyTrans('Fee') }}</dt>
+        <dd>{{ attribute(tags, 'fee') ? tagTrans('fee', attribute(tags, 'fee')) : '' }}</dd>
+
+        <dt>{{ keyTrans('Wheelchair') }}</dt>
+        <dd>{{ attribute(tags, 'wheelchair') ? tagTrans('wheelchair', attribute(tags, 'wheelchair')) : '' }}</dd>
+
+        <dt>{{ trans('Photos') }}</dt>
+        <dd>
+          <ul>
+            {% if attribute(tags, 'mapillary') %}
+              <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
+            {% endif %}
+          </ul>
+        </dd>
+      </dl>
+    {% endif %}   
+  markerSign: '{{ item[''sign''] }}'
+
+  priority: |-
+    {% if item is defined %}
+      {{ item['priority'] }}
+    {% else %}
+      10
+    {% endif %}
+
+const:
+  canoe=put_in:
+    sign: 🛶
+    priority: 0
+  leisure=slipway:
+    sign: 🚣🏻
+    priority: 1
+  canoe=portage:
+    sign: 🚶🏻
+    priority: 2
+  shop=boat:
+    sign: 🛒
+    priority: 3
+  shop=rental:
+    sign: 🛒
+    priority: 3

--- a/paddling_amenities.yaml
+++ b/paddling_amenities.yaml
@@ -1,75 +1,106 @@
 type: overpass
 name:
-  en: Paddling Hazards
+  en: Paddling Amenities
 query:
-  '13': |-
+  '14': |-
     (
-      nwr[waterway~"^(dam|weir|waterfall|rapids|lock|lock_gate|sluice_gate)$"];
+      node["canoe"="put_in"];
+      node["leisure"="slipway"];
+      way["canoe"="portage"];
+      nwr[shop~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
+      nwr[rental~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
+      nwr["canoe_rental"="yes"];
+      nwr["kayak_rental"="yes"];
+      nwr["standup_paddleboard_rental"="yes"];
+      nwr["dinghy_rental"="yes"];
+      nwr["pedalboat_rental"="yes"];
     )
 feature:
   pre: |-
-    {% if tags.waterway %}
+    {% if tags.canoe == 'portage' and ( not attribute(tags, 'surface') or attribute(tags, 'surface') == 'water' ) %}
       {% set key = 'waterway' %}
-      {% set value = tags.waterway %}
+      {% set value = 'portage' %}
+    {% elseif tags.canoe %}
+      {% set key = 'canoe' %}
+      {% set value = tags.canoe %}
+    {% elseif tags.leisure %}
+      {% set key = 'leisure' %}
+      {% set value = tags.leisure %}
+    {% elseif tags.shop %}
+      {% set key = 'shop' %}
+      {% set value = 'shop' %}
+    {% elseif tags.rental or tags.canoe_rental or tags.kayak_rental or tags.standup_paddleboard_rental or tags.dingy_rental or tags.pedalboat_rental %}
+      {% set key = 'shop' %}
+      {% set value = 'rental' %}
     {% endif %}
 
     {% set constIndex = (key ~ "=" ~ value) %}
     {% set item = const[constIndex] %}
   title: |
-    {{ item['sign'] }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
+    {{ localizedTag(tags, 'name') }}
+    {% if attribute(tags, 'ref') %}
+      ( {{ localizedTag(tags, 'ref') }} )
+    {% endif %}
   description: |
     {{ tagTrans(key, value) }}
   body: |-
-    <dl>
-      <dt>{{ keyTrans('Description') }}</dt>
-      <dd>{{ localizedTag(tags, 'description') }}</dd>
-      
-      {% if attribute(tags, 'operator') %}
+    {% if constIndex in ['canoe=put_in', 'leisure=slipway','canoe=portage'] %}
+      <dl>
+        <dt>{{ keyTrans('Description') }}</dt>
+        <dd>{{ localizedTag(tags, 'description') }}</dd>
+
+        <dt>{{ keyTrans('Surface') }}</dt>
+        <dd>{{ attribute(tags, 'surface') ? tagTrans('surface', attribute(tags, 'surface')) : '' }}</dd>
+
         <dt>{{ keyTrans('Operator') }}</dt>
         <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
-      {% endif %}
 
-      <dt>{{ trans('Photos') }}</dt>
-      <dd>
-        <ul>
-          {% if attribute(tags, 'mapillary') %}
-            <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
-          {% endif %}
-        </ul>
-      </dd>
+        <dt>{{ keyTrans('Access') }}</dt>
+        <dd>{{ attribute(tags, 'access') ? tagTrans('access', attribute(tags, 'access')) : '' }}</dd>
 
-    </dl>
-  markerSign: '⚠️'
+        <dt>{{ keyTrans('Fee') }}</dt>
+        <dd>{{ attribute(tags, 'fee') ? tagTrans('fee', attribute(tags, 'fee')) : '' }}</dd>
+
+        <dt>{{ keyTrans('Wheelchair') }}</dt>
+        <dd>{{ attribute(tags, 'wheelchair') ? tagTrans('wheelchair', attribute(tags, 'wheelchair')) : '' }}</dd>
+
+        <dt>{{ trans('Photos') }}</dt>
+        <dd>
+          <ul>
+            {% if attribute(tags, 'mapillary') %}
+              <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
+            {% endif %}
+          </ul>
+        </dd>
+      </dl>
+    {% endif %}   
+  markerSign: '{{ item[''sign''] | raw }}'
   markerSymbol: |
-      {{ markerPointer({ fillColor: '#FFFFFF' }) }}
+    {% if item['sign'] %}{{ markerPointer({ fillColor: '#FFFFFF' }) }}{% endif %}
   listMarkerSymbol: |
-    {{ markerCircle({ fillColor: '#FFFFFF' }) }}
+    {% if item['sign'] %}{{ markerCircle({ fillColor: '#FFFFFF' }) }}{% endif %}
   priority: |-
-    {% if const[constIndex] is defined %}
-      {{ const[constIndex]['priority'] }}
+    {% if item is defined %}
+      {{ item['priority'] }}
     {% else %}
       10
     {% endif %}
 const:
-  waterway=dam:
-    sign: '🦫'
+  canoe=portage:
+    sign: <i class="fas fa-walking"></i>
+    priority: 2
+  canoe=put_in:
+    sign: <i class="fas fa-expand-alt"></i>
     priority: 0
-  waterway=weir:
-    sign: '🦫'
-    priority: 0
-  waterway=waterfall:
-    sign: '🌊'
-    priority: 0
-  waterway=rapids:
-    sign: '🌊'
-    priority: 0
-  waterway=lock:
-    sign: '🚪'
+  leisure=slipway:
+    sign: <i class="fas fa-ship"></i>
     priority: 1
-  waterway=lock_gate:
-    sign: '🚪'
-    priority: 1
-  waterway=sluice_gate:
-    sign: '🦫'
-    priority: 0
-
+  shop=shop:
+    sign: <i class="fas fa-store-alt"></i>
+    priority: 3
+  shop=rental:
+    sign: <i class="fas fa-store"></i>
+    priority: 3
+  waterway=portage:
+    sign:
+    priority: 2

--- a/paddling_amenities.yaml
+++ b/paddling_amenities.yaml
@@ -1,99 +1,75 @@
 type: overpass
 name:
-  en: Paddling Amenities
+  en: Paddling Hazards
 query:
-  '14': |-
+  '13': |-
     (
-      node["canoe"="put_in"];
-      node["leisure"="slipway"];
-      way["canoe"="portage"];
-      nwr[shop~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
-      nwr[rental~"^(boat)$"]["boat:type"~"^(.*;|)canoe|kayak|standup_paddleboard|dinghy|pedalboat(|;.*)$"];
-      nwr["canoe_rental"="yes"];
-      nwr["kayak_rental"="yes"];
-      nwr["standup_paddleboard_rental"="yes"];
-      nwr["dinghy_rental"="yes"];
-      nwr["pedalboat_rental"="yes"];
+      nwr[waterway~"^(dam|weir|waterfall|rapids|lock|lock_gate|sluice_gate)$"];
     )
 feature:
   pre: |-
-    {% if tags.canoe %}
-      {% set key = 'canoe' %}
-      {% set value = tags.canoe %}
-    {% elseif tags.leisure %}
-      {% set key = 'leisure' %}
-      {% set value = tags.leisure %}
-    {% elseif tags.shop %}
-      {% set key = 'shop' %}
-      {% set value = tags.shop %}
-    {% elseif tags.rental or tags.canoe_rental or tags.kayak_rental or tags.standup_paddleboard_rental or tags.dingy_rental or tags.pedalboat_rental %}
-      {% set key = 'shop' %}
-      {% set value = 'rental' %}
+    {% if tags.waterway %}
+      {% set key = 'waterway' %}
+      {% set value = tags.waterway %}
     {% endif %}
 
     {% set constIndex = (key ~ "=" ~ value) %}
     {% set item = const[constIndex] %}
-
   title: |
-    {{ localizedTag(tags, 'name') }}
-    {% if attribute(tags, 'ref') %}
-      ( {{ localizedTag(tags, 'ref') }} )
-    {% endif %}
+    {{ item['sign'] }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
   description: |
     {{ tagTrans(key, value) }}
   body: |-
-    {% if constIndex in ['canoe=put_in', 'leisure=slipway','canoe=portage'] %}
-      <dl>
-        <dt>{{ keyTrans('Description') }}</dt>
-        <dd>{{ localizedTag(tags, 'description') }}</dd>
-
-        <dt>{{ keyTrans('Surface') }}</dt>
-        <dd>{{ attribute(tags, 'surface') ? tagTrans('surface', attribute(tags, 'surface')) : '' }}</dd>
-
+    <dl>
+      <dt>{{ keyTrans('Description') }}</dt>
+      <dd>{{ localizedTag(tags, 'description') }}</dd>
+      
+      {% if attribute(tags, 'operator') %}
         <dt>{{ keyTrans('Operator') }}</dt>
         <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
+      {% endif %}
 
-        <dt>{{ keyTrans('Access') }}</dt>
-        <dd>{{ attribute(tags, 'access') ? tagTrans('access', attribute(tags, 'access')) : '' }}</dd>
+      <dt>{{ trans('Photos') }}</dt>
+      <dd>
+        <ul>
+          {% if attribute(tags, 'mapillary') %}
+            <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
+          {% endif %}
+        </ul>
+      </dd>
 
-        <dt>{{ keyTrans('Fee') }}</dt>
-        <dd>{{ attribute(tags, 'fee') ? tagTrans('fee', attribute(tags, 'fee')) : '' }}</dd>
-
-        <dt>{{ keyTrans('Wheelchair') }}</dt>
-        <dd>{{ attribute(tags, 'wheelchair') ? tagTrans('wheelchair', attribute(tags, 'wheelchair')) : '' }}</dd>
-
-        <dt>{{ trans('Photos') }}</dt>
-        <dd>
-          <ul>
-            {% if attribute(tags, 'mapillary') %}
-              <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
-            {% endif %}
-          </ul>
-        </dd>
-      </dl>
-    {% endif %}   
-  markerSign: '{{ item[''sign''] }}'
-
+    </dl>
+  markerSign: '⚠️'
+  markerSymbol: |
+      {{ markerPointer({ fillColor: '#FFFFFF' }) }}
+  listMarkerSymbol: |
+    {{ markerCircle({ fillColor: '#FFFFFF' }) }}
   priority: |-
-    {% if item is defined %}
-      {{ item['priority'] }}
+    {% if const[constIndex] is defined %}
+      {{ const[constIndex]['priority'] }}
     {% else %}
       10
     {% endif %}
-
 const:
-  canoe=put_in:
-    sign: 🛶
+  waterway=dam:
+    sign: '🦫'
     priority: 0
-  leisure=slipway:
-    sign: 🚣🏻
+  waterway=weir:
+    sign: '🦫'
+    priority: 0
+  waterway=waterfall:
+    sign: '🌊'
+    priority: 0
+  waterway=rapids:
+    sign: '🌊'
+    priority: 0
+  waterway=lock:
+    sign: '🚪'
     priority: 1
-  canoe=portage:
-    sign: 🚶🏻
-    priority: 2
-  shop=boat:
-    sign: 🛒
-    priority: 3
-  shop=rental:
-    sign: 🛒
-    priority: 3
+  waterway=lock_gate:
+    sign: '🚪'
+    priority: 1
+  waterway=sluice_gate:
+    sign: '🦫'
+    priority: 0
+

--- a/paddling_hazards.yaml
+++ b/paddling_hazards.yaml
@@ -15,7 +15,6 @@ feature:
 
     {% set constIndex = (key ~ "=" ~ value) %}
     {% set item = const[constIndex] %}
-
   title: |
     {{ item['sign'] }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
   description: |
@@ -40,16 +39,17 @@ feature:
       </dd>
 
     </dl>
-
   markerSign: '⚠️'
-
+  markerSymbol: |
+      {{ markerPointer({ fillColor: '#FFFFFF' }) }}
+  listMarkerSymbol: |
+    {{ markerCircle({ fillColor: '#FFFFFF' }) }}
   priority: |-
     {% if const[constIndex] is defined %}
       {{ const[constIndex]['priority'] }}
     {% else %}
       10
     {% endif %}
-
 const:
   waterway=dam:
     sign: '🦫'

--- a/paddling_hazards.yaml
+++ b/paddling_hazards.yaml
@@ -1,0 +1,75 @@
+type: overpass
+name:
+  en: Paddling Hazards
+query:
+  '13': |-
+    (
+      nwr[waterway~"^(dam|weir|waterfall|rapids|lock|lock_gate|sluice_gate)$"];
+    )
+feature:
+  pre: |-
+    {% if tags.waterway %}
+      {% set key = 'waterway' %}
+      {% set value = tags.waterway %}
+    {% endif %}
+
+    {% set constIndex = (key ~ "=" ~ value) %}
+    {% set item = const[constIndex] %}
+
+  title: |
+    {{ item['sign'] }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
+  description: |
+    {{ tagTrans(key, value) }}
+  body: |-
+    <dl>
+      <dt>{{ keyTrans('Description') }}</dt>
+      <dd>{{ localizedTag(tags, 'description') }}</dd>
+      
+      {% if attribute(tags, 'operator') %}
+        <dt>{{ keyTrans('Operator') }}</dt>
+        <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
+      {% endif %}
+
+      <dt>{{ trans('Photos') }}</dt>
+      <dd>
+        <ul>
+          {% if attribute(tags, 'mapillary') %}
+            <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
+          {% endif %}
+        </ul>
+      </dd>
+
+    </dl>
+
+  markerSign: '⚠️'
+
+  priority: |-
+    {% if const[constIndex] is defined %}
+      {{ const[constIndex]['priority'] }}
+    {% else %}
+      10
+    {% endif %}
+
+const:
+  waterway=dam:
+    sign: '🦫'
+    priority: 0
+  waterway=weir:
+    sign: '🦫'
+    priority: 0
+  waterway=waterfall:
+    sign: '🌊'
+    priority: 0
+  waterway=rapids:
+    sign: '🌊'
+    priority: 0
+  waterway=lock:
+    sign: '🚪'
+    priority: 1
+  waterway=lock_gate:
+    sign: '🚪'
+    priority: 1
+  waterway=sluice_gate:
+    sign: '🦫'
+    priority: 0
+

--- a/paddling_hazards.yaml
+++ b/paddling_hazards.yaml
@@ -16,7 +16,7 @@ feature:
     {% set constIndex = (key ~ "=" ~ value) %}
     {% set item = const[constIndex] %}
   title: |
-    {{ item['sign'] }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
+    {{ item['sign'] | raw }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
   description: |
     {{ tagTrans(key, value) }}
   body: |-
@@ -39,11 +39,11 @@ feature:
       </dd>
 
     </dl>
-  markerSign: '⚠️'
+  markerSign: <i class="fas fa-exclamation-triangle"></i>
   markerSymbol: |
-      {{ markerPointer({ fillColor: '#FFFFFF' }) }}
+      {{ markerPointer({ fillColor: '#ff6700' }) }}
   listMarkerSymbol: |
-    {{ markerCircle({ fillColor: '#FFFFFF' }) }}
+    {{ markerCircle({ fillColor: '#ff6700' }) }}
   priority: |-
     {% if const[constIndex] is defined %}
       {{ const[constIndex]['priority'] }}
@@ -52,24 +52,24 @@ feature:
     {% endif %}
 const:
   waterway=dam:
-    sign: '🦫'
+    sign: <i class="fas fa-sort-amount-down-alt"></i>
     priority: 0
   waterway=weir:
-    sign: '🦫'
+    sign: <i class="fas fa-sort-amount-up-alt"></i>
     priority: 0
   waterway=waterfall:
-    sign: '🌊'
+    sign: <i class="far fa-chart-bar"></i>
     priority: 0
   waterway=rapids:
-    sign: '🌊'
+    sign: <i class="fas fa-water"></i>
     priority: 0
   waterway=lock:
-    sign: '🚪'
+    sign: <i class="fas fa-lock"></i>
     priority: 1
   waterway=lock_gate:
-    sign: '🚪'
+    sign: <i class="fas fa-torii-gate"></i>
     priority: 1
   waterway=sluice_gate:
-    sign: '🦫'
+    sign: <i class="fas fa-grip-lines"></i>
     priority: 0
 

--- a/paddling_hazards.yaml
+++ b/paddling_hazards.yaml
@@ -2,7 +2,7 @@ type: overpass
 name:
   en: Paddling Hazards
 query:
-  '13': |-
+  '12': |-
     (
       nwr[waterway~"^(dam|weir|waterfall|rapids|lock|lock_gate|sluice_gate)$"];
     )

--- a/paddling_routes.yaml
+++ b/paddling_routes.yaml
@@ -2,11 +2,11 @@ type: overpass
 name:
   en: Paddling Routes
 query:
-  '4': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn)(|;.*)$']
-  '6': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn)(|;.*)$']
-  '8': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn)(|;.*)$']
-  '10': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn|lpn)(|;.*)$']
-  '13': (relation[type=route][route~"^(|.*;)canoe(|;.*)$"]
+  '2': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn)(|;.*)$']
+  '4': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn)(|;.*)$']
+  '6': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn)(|;.*)$']
+  '8': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn|lpn)(|;.*)$']
+  '10': (relation[type=route][route~"^(|.*;)canoe(|;.*)$"]
 members: true
 feature:
   pre: |-

--- a/paddling_routes.yaml
+++ b/paddling_routes.yaml
@@ -1,0 +1,102 @@
+type: overpass
+name:
+  en: Paddling Routes
+query:
+  '4': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn)(|;.*)$']
+  '6': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn)(|;.*)$']
+  '8': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn)(|;.*)$']
+  '10': relation[type=route][route~"^(|.*;)canoe(|;.*)$"][network~'^(|.*;)(ipn|npn|rpn|lpn)(|;.*)$']
+  '13': (relation[type=route][route~"^(|.*;)canoe(|;.*)$"]
+members: true
+feature:
+  pre: |-
+    {% set network = tags.network %}
+    {% for n in tags.network|split(';') %}
+    {% if n|matches('pn$') %}{% set network = n %}{% endif %}
+    {% endfor %}
+  priority: '{{ const[network].priority|default(4) }}'
+  description: '{% if network %}{{ tagTrans(''network'', network) }}{% endif %}'
+  listMarkerSymbol: '{{ markerLine({ ''width'': 4, ''color'': const[network|default('''')].color|default(const[''''].color) })|raw }}'
+  title: '{% if tags.ref and tags.name %}{{ tags.ref }} - {{ tags.name }}{% elseif tags.ref %}{{ tags.ref }}{% elseif tags.name %}{{ tags.name }}{% endif %}'
+  styles: ''
+  markerSymbol: ''
+memberFeature:
+  pre: |-
+    {% set priority = 4 %}
+    {% set network = '' %}
+    {% set refs = [] %}
+
+    {% for master in masters %}
+      {% set masterNetwork = '' %}
+      {% for n in master.tags.network|split(';') %}
+        {% if n|matches('pn$') %}{% set masterNetwork = n %}{% endif %}
+      {% endfor %}
+      {% set _p = const[masterNetwork].priority|default(4) %}
+      {% if _p < priority %}
+        {% set priority = _p %}
+        {% set network = masterNetwork %}
+      {% endif %}
+      {% if master.tags.ref %}
+        {% set refs = refs|merge([ master.tags.ref ]) %}
+      {% endif %}
+    {% endfor %}
+  body: |-
+    <h4>Routes</h4>
+    <ul class='overpass-layer-list'>
+    {% for master in masters %}
+      {% set masterNetwork = '' %}
+      {% for n in master.tags.network|split(';') %}
+        {% if n|matches('pn$') %}{% set masterNetwork = n %}{% endif %}
+      {% endfor %}
+      <li data-object="{{ master.id }}"><a>
+        <div class='marker'>
+          <div class='symbol'>{{ markerLine({ width: 4, color: const[masterNetwork].color|default(const[''].color) })|raw }}</div>
+        </div>
+        <div class='content'>
+          <div class='description'>{{ tagTrans('network', masterNetwork) }}</div>
+          <div class='title'>{% if master.tags.ref and master.tags.name %}{{ master.tags.ref }} - {{ master.tags.name|default(master.tags.ref) }}{% elseif master.tags.ref %}{{ master.tags.ref }}{% elseif master.tags.name %}{{ master.tags.name }}{% endif %}</div>
+        </div>
+      </a></li>
+    {% endfor %}
+    </ul>
+  listExclude: '1'
+  style:
+    color: '{{ const[network].color }}'
+    width: 4
+    opacity: 1
+    text: '{{ refs|join('' · '') }}             '
+    textRepeat: '1'
+    textOffset: '12'
+    textFontWeight: bold
+const:
+  ipn:
+    color: '#ff0000'
+    priority: 0
+    zoom: 10
+  npn:
+    color: '#ff00ba'
+    priority: 1
+    zoom: 11
+  rpn:
+    color: '#ba00ff'
+    priority: 2
+    zoom: 12
+  lpn:
+    color: '#0000ff'
+    priority: 3
+    zoom: 14
+  '':
+    color: '#007fff'
+    priority: 4
+    zoom: 14
+info: |-
+  <table>
+  {% for value, data in const %}
+  {% if data.zoom <= map.zoom %}
+    <tr>
+      <td>{{ markerLine({ 'width': 4, color: data.color })|raw }}</td>
+      <td>{% if value %}{{ tagTrans('network', value) }}{% else %}{{ trans('unknown') }}{% endif %}</td>
+    </tr>
+  {% endif %}
+  {% endfor %}
+  </table>


### PR DESCRIPTION
Please consider adding these 3 new categories (routes, hazards and amenities) for human powered boating; canoe, kayak, standup paddleboards, row boats, pedalboats, etc. Guidance on the OpenStreetMap Wiki, states that the generic term/key/tag is "canoe".
* https://wiki.openstreetmap.org/wiki/Key:canoe
* https://wiki.openstreetmap.org/wiki/Tag:route%3Dcanoe

When naming these new categories I went with the term "paddling" as it seemed to be the most inclusive verb that matched the current practice on OpenStreetBrowser (cycling, hiking, climbing, etc).

To see an example of this work, here is a well mapped area, using my development repository:
https://openstreetbrowser.org/#map=17/42.74361/-84.54936&categories=treestryder./paddlecraft/paddling_amenities,treestryder./paddlecraft/paddling_hazards,treestryder./paddlecraft/paddling_routes
