### PR TITLE
Paddling detail views now match the format of detailsBody.html

### DIFF
--- a/paddling_amenities.yaml
+++ b/paddling_amenities.yaml
@@ -43,35 +43,53 @@ feature:
     {{ tagTrans(key, value) }}
   body: |-
     {% if constIndex in ['canoe=put_in', 'leisure=slipway','canoe=portage'] %}
-      <dl>
-        <dt>{{ keyTrans('Description') }}</dt>
-        <dd>{{ localizedTag(tags, 'description') }}</dd>
+      <ul>
+        {% if attribute(tags, 'surface') %}
+        <li class='hasSymbol'>
+          <i class='fa fa-window-minimize'></i>
+          {{ keyTrans('Surface') }}:
+          <span class='value'>{{ attribute(tags, 'surface') ? tagTrans('surface', attribute(tags, 'surface')) : '' }}</span>
+        </li>
+        {% endif %}
 
-        <dt>{{ keyTrans('Surface') }}</dt>
-        <dd>{{ attribute(tags, 'surface') ? tagTrans('surface', attribute(tags, 'surface')) : '' }}</dd>
 
-        <dt>{{ keyTrans('Operator') }}</dt>
-        <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
+        {% if attribute(tags, 'operator') %}
+        <li class='hasSymbol'>
+          <i class='fa fa-drivers-license-o'></i>
+          {{ keyTrans('Operator') }}:
+          <span class='value'>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</span>
+        </li>
+        {% endif %}
 
-        <dt>{{ keyTrans('Access') }}</dt>
-        <dd>{{ attribute(tags, 'access') ? tagTrans('access', attribute(tags, 'access')) : '' }}</dd>
+        {% if attribute(tags, 'access') %}
+        <li class='hasSymbol'>
+          <i class='fa fa-unlock'></i>
+          {{ keyTrans('Access') }}:
+          <span class='value'>{{ attribute(tags, 'access') ? tagTrans('access', attribute(tags, 'access')) : '' }}</span>
+        </li>
+        {% endif %}
 
-        <dt>{{ keyTrans('Fee') }}</dt>
-        <dd>{{ attribute(tags, 'fee') ? tagTrans('fee', attribute(tags, 'fee')) : '' }}</dd>
+        {% if attribute(tags, 'fee') %}
+        <li class='hasSymbol'>
+          <i class='fa fa-money'></i>
+          {{ keyTrans('Fee') }}:
+          <span class='value'>{{ attribute(tags, 'fee') ? tagTrans('fee', attribute(tags, 'fee')) : '' }}</span>
+        </li>
+        {% endif %}
 
-        <dt>{{ keyTrans('Wheelchair') }}</dt>
-        <dd>{{ attribute(tags, 'wheelchair') ? tagTrans('wheelchair', attribute(tags, 'wheelchair')) : '' }}</dd>
+        {% if attribute(tags, 'mapillary') %}
+        <li class='hasSymbol'>
+          <i class='fa fa-camera'></i>
+          {{ trans('Photos') }}:
+          <span class='value'>
+            <a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a>
+          </span>
+        </li>
+        {% endif %}
 
-        <dt>{{ trans('Photos') }}</dt>
-        <dd>
-          <ul>
-            {% if attribute(tags, 'mapillary') %}
-              <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
-            {% endif %}
-          </ul>
-        </dd>
-      </dl>
-    {% endif %}   
+      </ul>
+    {% endif %}
+    <!-- Description and Wheelchair rendered from detailsBody.html. -->
   markerSign: '{{ item[''sign''] | raw }}'
   markerSymbol: |
     {% if item['sign'] %}{{ markerPointer({ fillColor: '#FFFFFF' }) }}{% endif %}

--- a/paddling_hazards.yaml
+++ b/paddling_hazards.yaml
@@ -3,12 +3,23 @@ query:
   '12': |-
     (
       nwr[waterway~"^(dam|weir|waterfall|rapids|lock|lock_gate|sluice_gate)$"];
+      nwr["seamark:restricted_area:restriction"~"no_entry|restricted_entry"];
+      node["seamark:bridge:clearance_height"];
     )
 feature:
   pre: |-
     {% if tags.waterway %}
       {% set key = 'waterway' %}
       {% set value = tags.waterway %}
+    {% elseif attribute(tags, 'seamark:restricted_area:restriction') %}
+      {% set key = 'seamark:restricted_area:restriction' %}
+      {% set value = '' %}
+    {% elseif attribute(tags, 'seamark:bridge:clearance_height') %}
+      {% set key = 'seamark:bridge:clearance_height' %}
+      {% set value = attribute(tags, 'seamark:bridge:clearance_height') | round %}
+      {% if value > 4 %}
+        {% set value = 4 %}
+      {% endif %}
     {% endif %}
 
     {% set constIndex = (key ~ "=" ~ value) %}
@@ -16,27 +27,51 @@ feature:
   title: |
     {{ item['sign'] | raw }} {{ localizedTag(tags, 'name') | default(localizedTag(tags, 'key')) | default(localizedTag(tags, 'ref')) }}
   description: |
-    {{ tagTrans(key, value) }}
+    {% if key == 'seamark:restricted_area:restriction' %}
+      {{ attribute(tags, 'seamark:restricted_area:restriction') }}
+    {% elseif key == 'seamark:bridge:clearance_height' %}
+      {{ attribute(tags, 'seamark:bridge:clearance_height') }} Meters
+    {% else %}
+      {{ tagTrans(key, value) }}
+    {% endif %}
   body: |-
-    <dl>
-      <dt>{{ keyTrans('Description') }}</dt>
-      <dd>{{ localizedTag(tags, 'description') }}</dd>
-      
+    <ul>
+
       {% if attribute(tags, 'operator') %}
-        <dt>{{ keyTrans('Operator') }}</dt>
-        <dd>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</dd>
+      <li class='hasSymbol'>
+        <i class='fa fa-drivers-license-o'></i>
+        {{ keyTrans('Operator') }}:
+        <span class='value'>{{ attribute(tags, 'operator') ? tagTrans('operator', attribute(tags, 'operator')) : '' }}</span>
+      </li>
       {% endif %}
 
-      <dt>{{ trans('Photos') }}</dt>
-      <dd>
-        <ul>
-          {% if attribute(tags, 'mapillary') %}
-            <li><a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a></li>
-          {% endif %}
-        </ul>
-      </dd>
+      {% if attribute(tags, 'height') %}
+      <li class='hasSymbol'>
+        <i class='fa-solid fa-ruler-vertical'></i>
+        {{ keyTrans('Height') }}:
+        <span class='value'>{{ attribute(tags, 'height') ? tagTrans('height', attribute(tags, 'height')) : '' }}</span>
+      </li>
+      {% endif %}
 
-    </dl>
+      {% if attribute(tags, 'width') %}
+      <li class='hasSymbol'>
+        <i class='fas fa-ruler-horizontal'></i>
+        {{ keyTrans('Width') }}:
+        <span class='value'>{{ attribute(tags, 'width') ? tagTrans('width', attribute(tags, 'width')) : '' }}</span>
+      </li>
+      {% endif %}
+
+      {% if attribute(tags, 'mapillary') %}
+      <li class='hasSymbol'>
+        <i class='fa fa-camera'></i>
+        {{ trans('Photos') }}:
+        <span class='value'>
+          <a href="https://www.mapillary.com/app/?focus=photo&pKey={{ attribute(tags, 'mapillary') }}" rel="noreferrer" target="_blank">Mapillary</a>
+        </span>
+      </li>
+      {% endif %}
+
+    </ul>
   markerSign: <i class="fas fa-exclamation-triangle"></i>
   markerSymbol: |
       {{ markerPointer({ fillColor: '#ff6700' }) }}
@@ -70,4 +105,21 @@ const:
   waterway=sluice_gate:
     sign: <i class="fas fa-grip-lines"></i>
     priority: 0
-
+  seamark:restricted_area:restriction=:
+    sign: <i class='fa fa-times-rectangle-o'></i>
+    priority: 1
+  seamark:bridge:clearance_height=0:
+    sign: <i class='fa fa-thermometer-0'></i>
+    priority: 0
+  seamark:bridge:clearance_height=1:
+    sign: <i class='fa fa-thermometer-1'></i>
+    priority: 0
+  seamark:bridge:clearance_height=2:
+    sign: <i class='fa fa-thermometer-2'></i>
+    priority: 0
+  seamark:bridge:clearance_height=3:
+    sign: <i class='fa fa-thermometer-3'></i>
+    priority: 0
+  seamark:bridge:clearance_height=4:
+    sign: <i class='fa fa-thermometer-4'></i>
+    priority: 0


### PR DESCRIPTION
This looks better.
Example
https://openstreetbrowser.org/#map=17/42.71741/-84.56120&categories=treestryder./paddlecraft/paddling_amenities,treestryder./paddlecraft/paddling_hazards